### PR TITLE
Add missing Flask-Limiter dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ gunicorn==22.0.0
 apscheduler==3.10.4
 tenacity==8.5
 Flask-Redis==0.4.0
+Flask-Limiter==3.6.0


### PR DESCRIPTION
## Summary
- include Flask-Limiter in requirements to install rate-limiting library

## Testing
- `python -m py_compile app/routes/tab1.py app/routes/tab3.py`
- `python -m pip install 'Flask-Limiter'` *(fails: ProxyError 403)*

------
https://chatgpt.com/codex/tasks/task_e_6892aeec8c0083259025d87bc6c03486